### PR TITLE
Enable users to pass flags

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -12,6 +12,8 @@ GitHub allows you to [co-author commits](https://help.github.com/articles/creati
 
 To speed up your workflow you can preinstall co-commit using `npm i -g co-commit`.
 
+You can also utilize git flags with co-commit: eg `git commit --all` becomes `npx co-commit --all`. Additionally, you can skip prompts using flags: eg: `-m "your commit message"` or `-co "mariiapunda, juliettepretot"`.
+
 ## ⛓ Dependencies
 
 [Git](https://git-scm.com/), [NodeJs](https://nodejs.org/en/).

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "arg": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npmjs.org/arg/-/arg-2.0.0.tgz",
+      "integrity": "sha512-XxNTUzKnz1ctK3ZIcI2XUPlD96wbHP2nGqkPKpvk/HNRlPveYrXIVSTk9m3LcqOgDPg3B1nMvdV/K8wZd7PG4w=="
+    },
     "kleur": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "index.js"
   ],
   "dependencies": {
+    "arg": "^2.0.0",
     "prompts": "^1.1.1"
   }
 }


### PR DESCRIPTION
Enables users to utilize git flags with co-commit: eg git commit --all becomes npx commit --all.

Additionally, users can skip prompts using flags: eg: -m "your commit message" or -c "mariiapunda, juliettepretot".

To me this appears like it may be a handy feature. However, we should also consider that it adds another dependency & increases the complexity of the script.