### PR TITLE
Remove prompts dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,27 +1,5 @@
 {
   "name": "co-commit",
   "version": "0.2.7",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "kleur": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-2.0.2.tgz",
-      "integrity": "sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ=="
-    },
-    "prompts": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-1.1.1.tgz",
-      "integrity": "sha512-lC0+ifgWNKhTNF28Wj41TOXE+gEzrHcDqkCRHMbv39afuGT1ClekTgcVF+r2VuSgNr3Fy2hq6Pu3Mlt43u+QlQ==",
-      "requires": {
-        "kleur": "^2.0.1",
-        "sisteransi": "^1.0.0"
-      }
-    },
-    "sisteransi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
-      "integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ=="
-    }
-  }
+  "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,5 @@
   "files": [
     "index.js"
   ],
-  "dependencies": {
-    "prompts": "^1.1.1"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
Removes prompts dependency and replaces it with a simple prompt function.

We use only a small subset of the features of prompts, so it may not make sense to utilize the library, even though it is relatively small.

Doing this speeds up runs of npx co-commit by ~200ms (with cache). It speeds up the first run by around ~1s.

That said by removing prompts we also remove validation. Furthermore, the prompts library is well tested & reliable.